### PR TITLE
Added way to check whether video stream is frozen

### DIFF
--- a/src/ardrone/ardrone.cpp
+++ b/src/ardrone/ardrone.cpp
@@ -58,6 +58,7 @@ ARDrone::ARDrone()
     pFrameBGR   = NULL;
     bufferBGR   = NULL;
     pConvertCtx = NULL;
+    newImage    = true;
 
     // Thread for AT command
     threadCommand = NULL;

--- a/src/ardrone/ardrone.cpp
+++ b/src/ardrone/ardrone.cpp
@@ -58,7 +58,7 @@ ARDrone::ARDrone()
     pFrameBGR   = NULL;
     bufferBGR   = NULL;
     pConvertCtx = NULL;
-    newImage    = true;
+    newImage    = false;
 
     // Thread for AT command
     threadCommand = NULL;

--- a/src/ardrone/ardrone.h
+++ b/src/ardrone/ardrone.h
@@ -1054,6 +1054,7 @@ public:
     // Get an image
     virtual ARDRONE_IMAGE getImage(void);
     virtual ARDrone& operator >> (cv::Mat &image);
+    virtual bool willGetNewImage(void);
 
     // Get AR.Drone's firmware version
     virtual int getVersion(int *major = NULL, int *minor = NULL, int *revision = NULL);
@@ -1124,6 +1125,7 @@ protected:
     AVFrame         *pFrame, *pFrameBGR;
     uint8_t         *bufferBGR;
     SwsContext      *pConvertCtx;
+    bool            newImage;
 
     // Thread for AT command
     pthread_t *threadCommand;


### PR DESCRIPTION
The video stream often freezes briefly, meaning that subsequent calls to ```ARDrone::getImage()``` will return the same image as before. I added ```ARDrone::willGetNewImage()``` to check whether we've received a new image since the last call to ```ARDrone::getImage()```. This is useful in, e.g., computer vision, where it might be undesirable to process a frame that's identical to the one before it.