### PR TITLE
Fix bugs on make

### DIFF
--- a/build/unix/makefile
+++ b/build/unix/makefile
@@ -16,7 +16,6 @@ LIBS          = -lm                     \
                 -lopencv_features2d     \
                 -lopencv_flann          \
                 -lopencv_highgui        \
-                -lopencv_imgcodecs      \
                 -lopencv_imgproc        \
                 -lopencv_ml             \
                 -lopencv_objdetect      \

--- a/src/ardrone/video.cpp
+++ b/src/ardrone/video.cpp
@@ -78,13 +78,13 @@ int ARDrone::initVideo(void)
         pFrame = avcodec_alloc_frame();
         pFrameBGR = avcodec_alloc_frame();
         #endif
-        bufferBGR = (uint8_t*)av_mallocz(avpicture_get_size(PIX_FMT_BGR24, pCodecCtx->width, pCodecCtx->height) * sizeof(uint8_t));
+        bufferBGR = (uint8_t*)av_mallocz(avpicture_get_size(AV_PIX_FMT_BGR24, pCodecCtx->width, pCodecCtx->height) * sizeof(uint8_t));
 
         // Assign appropriate parts of buffer to image planes in pFrameBGR
-        avpicture_fill((AVPicture*)pFrameBGR, bufferBGR, PIX_FMT_BGR24, pCodecCtx->width, pCodecCtx->height);
+        avpicture_fill((AVPicture*)pFrameBGR, bufferBGR, AV_PIX_FMT_BGR24, pCodecCtx->width, pCodecCtx->height);
 
         // Convert it to BGR
-        pConvertCtx = sws_getContext(pCodecCtx->width, pCodecCtx->height, pCodecCtx->pix_fmt, pCodecCtx->width, pCodecCtx->height, PIX_FMT_BGR24, SWS_SPLINE, NULL, NULL, NULL);
+        pConvertCtx = sws_getContext(pCodecCtx->width, pCodecCtx->height, pCodecCtx->pix_fmt, pCodecCtx->width, pCodecCtx->height, AV_PIX_FMT_BGR24, SWS_SPLINE, NULL, NULL, NULL);
     }
     // AR.Drone 1.0
     else {
@@ -100,7 +100,7 @@ int ARDrone::initVideo(void)
         pCodecCtx->height = 240;
 
         // Allocate a buffer
-        bufferBGR = (uint8_t*)av_mallocz(avpicture_get_size(PIX_FMT_BGR24, pCodecCtx->width, pCodecCtx->height));
+        bufferBGR = (uint8_t*)av_mallocz(avpicture_get_size(AV_PIX_FMT_BGR24, pCodecCtx->width, pCodecCtx->height));
     }
 
     // Allocate an IplImage


### PR DESCRIPTION
Hello!

I fixed some bugs on make for mac(unix).

### PIX_FMT_BGR24 error
on make, this error occurred.
```
../../src/ardrone/video.cpp:81:61: error: use of undeclared identifier 'PIX_FMT_BGR24'; did you mean 'AV_PIX_FMT_BGR24'?
        bufferBGR = (uint8_t*)av_mallocz(avpicture_get_size(PIX_FMT_BGR24, pCodecCtx->width, pCodecCtx->height) * sizeof...
                                                            ^~~~~~~~~~~~~
                                                            AV_PIX_FMT_BGR24
../../src/ardrone/video.cpp:87:132: error: use of undeclared identifier 'PIX_FMT_BGR24'; did you mean 'AV_PIX_FMT_BGR24'?
  ...pCodecCtx->height, pCodecCtx->pix_fmt, pCodecCtx->width, pCodecCtx->height, PIX_FMT_BGR24, SWS_SPLINE, NULL, NULL, NULL);
                                                                                 ^~~~~~~~~~~~~
                                                                                 AV_PIX_FMT_BGR24
../../src/ardrone/video.cpp:103:61: error: use of undeclared identifier 'PIX_FMT_BGR24'; did you mean 'AV_PIX_FMT_BGR24'?
        bufferBGR = (uint8_t*)av_mallocz(avpicture_get_size(PIX_FMT_BGR24, pCodecCtx->width, pCodecCtx->height));
                                                            ^~~~~~~~~~~~~
                                                            AV_PIX_FMT_BGR24
```

Recent ffmpeg(>=3.0) doesn't declare PIX_FMT_BGR24, discussed in [this issue](https://github.com/opencv/opencv/issues/5762).

### library option error
on make, this error occurred.
```
g++ ../../src/ardrone/ardrone.o ../../src/ardrone/command.o ../../src/ardrone/config.o ../../src/ardrone/udp.o ../../src/ardrone/tcp.o ../../src/ardrone/navdata.o ../../src/ardrone/version.o ../../src/ardrone/video.o ../../src/main.o -o test.a -O2 -Wall -D__STDC_CONSTANT_MACROS   -lm -lpthread -lavutil -lavformat -lavcodec -lswscale -lopencv_calib3d -lopencv_core -lopencv_features2d -lopencv_flann -lopencv_highgui -lopencv_imgcodecs -lopencv_imgproc -lopencv_ml -lopencv_objdetect -lopencv_photo -lopencv_stitching -lopencv_superres -lopencv_video -lopencv_videoio -lopencv_videostab
ld: library not found for -lopencv_imgcodecs
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [test.a] Error 1
```

opencv_imgcodecs not found in opencv 2.4, discussed in [this issue](https://github.com/opencv/opencv/issues/4966)

# env
```
$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.11.5
BuildVersion:	15F34
$  brew info opencv
homebrew/science/opencv: stable 2.4.13 (bottled), HEAD
Open source computer vision library
$ ffmpeg
ffmpeg version 3.0.2 Copyright (c) 2000-2016 the FFmpeg developers
```